### PR TITLE
STARK Poseidon BN254

### DIFF
--- a/packages/hashes/__tests__/stark-poseidon-bn254.test.ts
+++ b/packages/hashes/__tests__/stark-poseidon-bn254.test.ts
@@ -1,0 +1,24 @@
+import { StarkPoseidonBN254Hasher } from "../src";
+
+describe("Stark Poseidon Hash", () => {
+  it("Should compute a hash", () => {
+    const hasher = new StarkPoseidonBN254Hasher();
+    const a = "0x6109f1949f6a7555eccf4e15ce1f10fbd78091dfe715cc2e0c5a244d9d17761";
+    const b = "0x0194791558611599fe4ae0fcfa48f095659c90db18e54de86f2d2f547f7369bf";
+
+    expect(hasher.isElementSizeValid(a)).toBeTruthy();
+    expect(hasher.isElementSizeValid(b)).toBeTruthy();
+
+    expect(hasher.hash([a, b])).toEqual("0x16f02e8add49962d6003bb2ae7cc4bdad54077c1f9ec827867177f69df850217");
+  });
+
+  it("Should throw", () => {
+    const hasher = new StarkPoseidonBN254Hasher();
+    const a = `0x6109f1949f6a7555eccf4e15ce1f10fbd78091dfe715cc2e0c5a244d9d177610x6109f1949f6a7555eccf4e15ce1f10fbd78091dfe715cc2e0c5a244d9d177610x6109f1949f6a7555eccf4e15ce1f10fbd78091dfe715cc2e0c5a244d9d177610x6109f1949f6a7555eccf4e15ce1f10fbd78091dfe715cc2e0c5a244d9d177610x6109f1949f6a7555eccf4e15ce1f10fbd78091dfe715cc2e0c5a244d9d177610x6109f1949f6a7555eccf4e15ce1f10fbd78091dfe715cc2e0c5a244d9d177610x6109f1949f6a7555eccf4e15ce1f10fbd78091dfe715cc2e0c5a244d9d177610x6109f1949f6a7555eccf40x6109f1949f6a7555eccf4e15ce1f10fbd78091dfe715cc2e0c5a244d9d177610x6109f1949f6a7555eccf4e15ce1f10fbd78091dfe715cc2e0c5a244d9d177610x6109f1949f6a7555eccf4e15ce1f10fbd78091dfe715cc2e0c5a244d9d177610x6109f1949f6a7555eccf4e15ce1f10fbd78091dfe715cc2e0c5a244d9d177610x6109f1949f6a7555eccf4e15ce1f10fbd78091dfe715cc2e0c5a244d9d177610x6109f1949f6a7555eccf4e15ce1f10fbd78091dfe715cc2e0c5a244d9d177610x6109f1949f6a7555eccf4e15ce1f10fbd78091dfe715cc2e0c5a244d9d177610x6109f1949f6a7555eccf4`;
+    const b = "0x0194791558611599fe4ae0fcfa48f095659c90db18e54de86f2d2f547f7369bf";
+
+    expect(hasher.isElementSizeValid(a)).toBeFalsy();
+
+    expect(() => hasher.hash([a, b])).toThrowError("Stark Poseidon BN254 Hasher only accepts elements of size");
+  });
+});

--- a/packages/hashes/package.json
+++ b/packages/hashes/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@herodotus_dev/mmr-core": "^1.1.17",
+    "@noble/curves": "^1.0.0",
     "@types/node": "^18.15.0",
     "circomlibjs": "^0.1.7",
     "ethers": "5.7.2",

--- a/packages/hashes/src/index.ts
+++ b/packages/hashes/src/index.ts
@@ -2,3 +2,4 @@ export * from "./stark-pedersen-hasher";
 export * from "./poseidon-hasher";
 export * from './keccak-hasher';
 export * from './stark-poseidon-hasher';
+export * from './stark-poseidon-bn254-hasher';

--- a/packages/hashes/src/stark-poseidon-bn254-hasher.ts
+++ b/packages/hashes/src/stark-poseidon-bn254-hasher.ts
@@ -1,0 +1,37 @@
+import { IHasher } from "@herodotus_dev/mmr-core";
+import { poseidonBasic } from "micro-starknet";
+import { Field } from "@noble/curves/abstract/modular";
+
+const MDS_SMALL = [
+  [3, 1, 1],
+  [1, -1, 1],
+  [1, 1, -2],
+].map((i) => i.map(BigInt));
+
+export const P = Field(
+  BigInt('0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001')
+);
+
+const poseidonSmall = poseidonBasic(
+  { Fp: P, rate: 2, capacity: 1, roundsFull: 8, roundsPartial: 83 },
+  MDS_SMALL
+);
+
+export class StarkPoseidonBN254Hasher extends IHasher {
+  constructor() {
+    super({ blockSizeBits: 254 });
+  }
+
+  hash(data: string[]): string {
+    if (data.length !== 2) throw new Error("Stark Poseidon BN254 Hasher only accepts two elements");
+
+    const sizeErrorIndex = data.findIndex((e) => this.isElementSizeValid(e) === false);
+    if (sizeErrorIndex > -1)
+      throw new Error(
+        `Stark Poseidon BN254 Hasher only accepts elements of size ${this.options.blockSizeBits} bits. Got ${JSON.stringify(
+          IHasher.byteSize(data[sizeErrorIndex])
+        )}`
+      );
+    return "0x" + poseidonSmall([BigInt(data[0]), BigInt(data[1]), 2n])[0].toString(16);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -966,7 +966,7 @@
     validate-npm-package-name "^4.0.0"
     yargs-parser "20.2.4"
 
-"@noble/curves@~1.0.0":
+"@noble/curves@^1.0.0", "@noble/curves@~1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.0.0.tgz#e40be8c7daf088aaf291887cbc73f43464a92932"
   integrity sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==


### PR DESCRIPTION
Same as #26 but over the BN54 field.

Using [micro-starknet](https://github.com/paulmillr/micro-starknet) for the poseidon implementation and [noble-curves](https://github.com/paulmillr/noble-curves) to define the field.