### PR TITLE
Fixed sqlite getMany

### DIFF
--- a/packages/sqlite3/__tests__/store.test.ts
+++ b/packages/sqlite3/__tests__/store.test.ts
@@ -27,6 +27,21 @@ describe("SQLite3: In memory Database interactions", () => {
     expect(values.get("key1")).toEqual("value1");
   });
 
+  it("should get many values in correct order", async () => {
+    const entries = new Map<string, string>();
+    entries.set("a", "value1");
+    entries.set("b", "value2");
+    entries.set("10", "value3");
+    entries.set("5", "value4");
+    await store.setMany(entries);
+
+    const keysToGet = ["5", "10", "b", "a"];
+    const res = await store.getMany(keysToGet);
+    const keysGot = [...res.keys()];
+
+    expect(keysGot).toEqual(keysToGet);
+  });
+
   it("should delete a value", async () => {
     await store.set("key", "value");
     await store.delete("key");
@@ -57,6 +72,21 @@ describe("SQLite3: In persistent Database interactions", () => {
 
     const values = await store.getMany(["key1", "key2"]);
     expect(values.get("key1")).toEqual("value1");
+  });
+
+  it("should get many values in correct order", async () => {
+    const entries = new Map<string, string>();
+    entries.set("a", "value1");
+    entries.set("b", "value2");
+    entries.set("10", "value3");
+    entries.set("5", "value4");
+    await store.setMany(entries);
+
+    const keysToGet = ["5", "10", "b", "a"];
+    const res = await store.getMany(keysToGet);
+    const keysGot = [...res.keys()];
+
+    expect(keysGot).toEqual(keysToGet);
   });
 
   it("should delete a value", async () => {

--- a/packages/sqlite3/src/index.ts
+++ b/packages/sqlite3/src/index.ts
@@ -30,6 +30,7 @@ export default class SQLiteStore implements IStore {
   async getMany(keys: string[]): Promise<Map<string, string>> {
     const result = new Map<string, string>();
     if (keys.length === 0) return result;
+    keys.forEach((key) => result.set(key, ""));
     let query = "SELECT * FROM store WHERE key IN (";
 
     for (const key of keys) {


### PR DESCRIPTION
Sqlite query retrieves values in the alphabetic order which causes the `getMany` method to return values in a different order than they were requested. Now, the values are returned in the same order as the keys passed to `getMany`